### PR TITLE
fix(Zoom): :apple: Fix zooming/panning on Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ Custom Jupyterlab widget for TileDB
 
 ## Installation
 
-You can install using `pip`:
+You can install using `pip` and `jupyterlab`:
 
 ```bash
 pip install tiledb-plot-widget
+jupyter labextension install @tiledb-inc/tiledb-plot-widget
 ```
 
 Or if you use jupyterlab:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -131,9 +131,6 @@ jobs:
     vmImage: 'ubuntu-16.04'
 
   steps:
-  # - task: ExtractVersionFromTag@1
-  #   inputs:
-  #     projectFolderPath: '$(Build.SourcesDirectory)'
   - task: NodeTool@0
     inputs:
       versionSpec: '12.x'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiledb-inc/tiledb-plot-widget",
-  "version": "0.0.1",
+  "version": "0.1.3",
   "description": "Custom Jupyterlab widget for TileDB",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
Safari does not support SVG spec 2 but 1.1, therefore svg element can
not have transform attribute.