### PR TITLE
Use kebab-case CSS classes and add support for new statuses.

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -246,6 +246,7 @@ export class DagVisualizeView extends DOMWidgetView {
     }
     const numberOfNodes = nodes.length;
     const lessThanThirtyNodes = numberOfNodes < 30;
+    const smallNodeClass = lessThanThirtyNodes ? 'node--small' : '';
 
     /**
      * Sometimes during updates we are getting different/weird positions object
@@ -307,10 +308,13 @@ export class DagVisualizeView extends DOMWidgetView {
                 d.target.y
               }`;
             })
-            .attr('class', (d: Link) => `path-${d.target.status}`);
+            .attr('class', (d: Link) => `path-${toCSSClass(d.target.status)}`);
         },
         (update: any) =>
-          update.attr('class', (d: Link) => `path-${d.target.status}`)
+          update.attr(
+            'class',
+            (d: Link) => `path-${toCSSClass(d.target.status)}`
+          )
       );
 
       const circles = this.wrapper.selectAll('circle').data(nodes);
@@ -324,8 +328,7 @@ export class DagVisualizeView extends DOMWidgetView {
             .attr('r', circleSize)
             .attr(
               'class',
-              (d: NodeDetails) =>
-                `${d.status} ${lessThanThirtyNodes ? 'node--small' : ''}`
+              (d: NodeDetails) => `${toCSSClass(d.status)} ${smallNodeClass}`
             )
             .on('mouseover', (event: any, d: NodeDetails) => {
               const caption = d.name || d.id;
@@ -345,8 +348,7 @@ export class DagVisualizeView extends DOMWidgetView {
         (update: any) => {
           update.attr(
             'class',
-            (d: NodeDetails) =>
-              `${d.status} ${lessThanThirtyNodes ? 'node--small' : ''}`
+            (d: NodeDetails) => `${toCSSClass(d.status)} ${smallNodeClass}`
           );
         },
         (exit: any) => {
@@ -371,4 +373,8 @@ export class DagVisualizeView extends DOMWidgetView {
     this.el.append(zoomOutButton);
     this.el.append(resetButton);
   }
+}
+
+function toCSSClass(status: string): string {
+  return status.toLowerCase().replace(/[ _]/g, '-');
 }

--- a/style/base.css
+++ b/style/base.css
@@ -63,11 +63,13 @@ svg{
   pointer-events: none;
 }
 
-.tiledb-widget .Not.Started {
+.tiledb-widget .not-started,
+.tiledb-widget .waiting,
+.tiledb-widget .ready {
   fill: var(--kashmir);
 }
 
-.tiledb-widget .Running {
+.tiledb-widget .running {
   animation: dash 15s linear;
   animation-iteration-count: infinite;
   fill: #66cc99;
@@ -76,11 +78,11 @@ svg{
   stroke-width: 3px;
 }
 
-.tiledb-widget .Running.node--small {
+.tiledb-widget .running.node--small {
   stroke-width: 1px;
 }
 
-.tiledb-widget .path-Running {
+.tiledb-widget .path-running {
   animation: dash-full 1s linear;
   animation-iteration-count: infinite;
   stroke-dasharray: 10;
@@ -96,15 +98,17 @@ svg{
   margin-top: 5px;
 }
 
-.tiledb-widget .Completed {
+.tiledb-widget .completed,
+.tiledb-widget .succeeded {
   fill: var(--success);
 }
 
-.tiledb-widget .Failed {
+.tiledb-widget .failed {
   fill: var(--danger);
 }
 
-.tiledb-widget .Cancelled {
+.tiledb-widget .cancelled,
+.tiledb-widget .parent-failed {
   fill: var(--warning);
 }
 


### PR DESCRIPTION
- Generates CSS class names by taking the status and making it
  `kebab-case`, to get safer class names.
- Adds support for the new and slightly changed status names that are
  used by the new version of task graphs.