### PR TITLE
Fix plot widget's release CI job

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -106,7 +106,7 @@ stages:
         versionSpec: '3.8'
         architecture: 'x64'
 
-    - script: 'pip install twine build setuptools setuptools_scm jupyter-packaging==0.10.6 jupyterlab==$(jupyterlab.version)'
+    - script: 'pip install twine build setuptools setuptools_scm jupyter-packaging==0.10.6 jupyterlab==3.6.5'
       displayName: 'Install twine/build'
 
     - task: NodeTool@0


### PR DESCRIPTION
Deploy stage doesn't have 'jupyterlab.version' env variable which fails the CI job

Story details: https://app.shortcut.com/tiledb-inc/story/32240